### PR TITLE
fix to add ctx to utils.get_image_id so that logging doesnt throw errors

### DIFF
--- a/docker_plugin/tasks.py
+++ b/docker_plugin/tasks.py
@@ -253,7 +253,8 @@ def pull(client, arguments, ctx):
                                       arguments,
                                       str(e)))
 
-    image_id = utils.get_image_id(arguments.get('tag'), image_id, client)
+    image_id = utils.get_image_id(
+        arguments.get('tag'), image_id, client, ctx=ctx)
     ctx.instance.runtime_properties['image_id'] = image_id
     ctx.logger.info('Pulled image, image_id: {0}'.format(image_id))
     return image_id
@@ -281,7 +282,8 @@ def import_image(client, arguments, ctx):
     ctx.logger.info('output: {}'.format(output))
     image_id = json.loads(output).get('status')
 
-    image_id = utils.get_image_id(arguments.get('tag'), image_id, client)
+    image_id = utils.get_image_id(
+        arguments.get('tag'), image_id, client, ctx=ctx)
     ctx.instance.runtime_properties['image_id'] = image_id
     ctx.logger.info('Imported image, image_id {0}'.format(image_id))
     return image_id

--- a/docker_plugin/tasks.py
+++ b/docker_plugin/tasks.py
@@ -113,13 +113,13 @@ def start(params, processes_to_wait_for, retry_interval,
         ctx.instance.runtime_properties['container_id']))
 
     if utils.get_container_dictionary(client, ctx=ctx) is not None:
-        inspect_output = utils.inspect_container(client)
+        inspect_output = utils.inspect_container(client, ctx=ctx)
         ctx.instance.runtime_properties['ports'] = \
             inspect_output.get('Ports', None)
         ctx.instance.runtime_properties['network_settings'] = \
             inspect_output.get('NetworkSettings', None)
 
-    top_info = utils.get_top_info(client)
+    top_info = utils.get_top_info(client, ctx=ctx)
 
     ctx.logger.info('Container: {0} Forwarded ports: {1} Top: {2}.'.format(
         ctx.instance.runtime_properties['container_id'],

--- a/docker_plugin/utils.py
+++ b/docker_plugin/utils.py
@@ -20,7 +20,7 @@ from cloudify import ctx
 from cloudify.exceptions import RecoverableError, NonRecoverableError
 
 
-def get_image_id(tag, image_id, client):
+def get_image_id(tag, image_id, client, ctx):
     """ Attempts to get the correct image id from Docker.
 
     :param tag: The image tag provided in the blueprint.
@@ -326,6 +326,7 @@ def get_container_id_from_name(name, client, ctx):
             return i
         else:
             raise NonRecoverableError('No such container: {}.'.format(name))
+
 
 def get_top_info(client):
     """Get container top info.

--- a/docker_plugin/utils.py
+++ b/docker_plugin/utils.py
@@ -16,7 +16,6 @@
 import docker
 
 # Cloudify Imports
-from cloudify import ctx
 from cloudify.exceptions import RecoverableError, NonRecoverableError
 
 
@@ -72,7 +71,7 @@ def get_image_id(tag, image_id, client, ctx):
                               'received during pull is valid.')
 
 
-def inspect_container(client):
+def inspect_container(client, ctx):
     """Inspect container.
 
     Call inspect with container id from
@@ -328,7 +327,7 @@ def get_container_id_from_name(name, client, ctx):
             raise NonRecoverableError('No such container: {}.'.format(name))
 
 
-def get_top_info(client):
+def get_top_info(client, ctx):
     """Get container top info.
     Get container top info using docker top function with container id
     from ctx.instance.runtime_properties['container'].


### PR DESCRIPTION
When writing unit tests, I found that I had neglected to add ctx to the function