### PR TITLE
updated test files to use the new image since the old one was removed

### DIFF
--- a/docker_plugin/tests/__init__.py
+++ b/docker_plugin/tests/__init__.py
@@ -11,3 +11,5 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+
+TEST_IMAGE = 'tutum/hello-world'

--- a/docker_plugin/tests/tests_import_image_workflow.py
+++ b/docker_plugin/tests/tests_import_image_workflow.py
@@ -22,13 +22,12 @@ from docker import Client
 
 # Cloudify Imports is imported and used in operations
 from cloudify.workflows import local
+from docker_plugin.tests import TEST_IMAGE
 
 IGNORED_LOCAL_WORKFLOW_MODULES = (
     'worker_installer.tasks',
     'plugin_installer.tasks'
 )
-
-TEST_IMAGE = 'tutum/hello-world'
 
 
 class TestImportImageWorkflow(testtools.TestCase):

--- a/docker_plugin/tests/tests_import_image_workflow.py
+++ b/docker_plugin/tests/tests_import_image_workflow.py
@@ -90,8 +90,8 @@ class TestImportImageWorkflow(testtools.TestCase):
         for i in client.images():
             repotags.append(i.get('RepoTags'))
 
-        self.assertFalse('{0}:latest'.format(TEST_IMAGE) in [tag for tag in repotags])
+        self.assertFalse(
+            '{0}:latest'.format(TEST_IMAGE) in [tag for tag in repotags])
         if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
             client.remove_image(TEST_IMAGE, force=True)
-

--- a/docker_plugin/tests/tests_import_image_workflow.py
+++ b/docker_plugin/tests/tests_import_image_workflow.py
@@ -28,6 +28,8 @@ IGNORED_LOCAL_WORKFLOW_MODULES = (
     'plugin_installer.tasks'
 )
 
+TEST_IMAGE = 'tutum/hello-world'
+
 
 class TestImportImageWorkflow(testtools.TestCase):
 
@@ -65,9 +67,9 @@ class TestImportImageWorkflow(testtools.TestCase):
                     ''.join([name for name in container.get('Names')]):
                 client.remove_container('test-container')
 
-        if ['docker-test-image:latest'] in \
+        if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
-            client.remove_image('docker-test-image', force=True)
+            client.remove_image(TEST_IMAGE, force=True)
 
         # execute install workflow
         self.env.execute('install', task_retries=0)
@@ -88,7 +90,8 @@ class TestImportImageWorkflow(testtools.TestCase):
         for i in client.images():
             repotags.append(i.get('RepoTags'))
 
-        self.assertFalse('docker-test-image' in [tag for tag in repotags])
-        if ['docker-test-image:latest'] in \
+        self.assertFalse('{0}:latest'.format(TEST_IMAGE) in [tag for tag in repotags])
+        if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
-            client.remove_image('docker-test-image', force=True)
+            client.remove_image(TEST_IMAGE, force=True)
+

--- a/docker_plugin/tests/tests_pull_workflow.py
+++ b/docker_plugin/tests/tests_pull_workflow.py
@@ -96,4 +96,3 @@ class TestPullWorkflow(testtools.TestCase):
         if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
             client.remove_image(TEST_IMAGE, force=True)
-

--- a/docker_plugin/tests/tests_pull_workflow.py
+++ b/docker_plugin/tests/tests_pull_workflow.py
@@ -22,13 +22,12 @@ from docker import Client
 
 # Cloudify Imports is imported and used in operations
 from cloudify.workflows import local
+from docker_plugin.tests import TEST_IMAGE
 
 IGNORED_LOCAL_WORKFLOW_MODULES = (
     'worker_installer.tasks',
     'plugin_installer.tasks'
 )
-
-TEST_IMAGE = 'tutum/hello-world'
 
 
 class TestPullWorkflow(testtools.TestCase):

--- a/docker_plugin/tests/tests_pull_workflow.py
+++ b/docker_plugin/tests/tests_pull_workflow.py
@@ -28,6 +28,8 @@ IGNORED_LOCAL_WORKFLOW_MODULES = (
     'plugin_installer.tasks'
 )
 
+TEST_IMAGE = 'tutum/hello-world'
+
 
 class TestPullWorkflow(testtools.TestCase):
 
@@ -38,7 +40,7 @@ class TestPullWorkflow(testtools.TestCase):
                                       'blueprint', 'test_pull.yaml')
 
         inputs = {
-            'test_repo': 'docker-test-image',
+            'test_repo': TEST_IMAGE,
             'test_tag': 'latest',
             'test_container_name': 'test-container'
         }
@@ -64,9 +66,9 @@ class TestPullWorkflow(testtools.TestCase):
                     ''.join([name for name in container.get('Names')]):
                 client.remove_container('test-container')
 
-        if ['docker-test-image:latest'] in \
+        if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
-            client.remove_image('docker-test-image', force=True)
+            client.remove_image(TEST_IMAGE, force=True)
 
         # execute install workflow
         self.env.execute('install', task_retries=0)
@@ -90,7 +92,8 @@ class TestPullWorkflow(testtools.TestCase):
         for i in client.images():
             repotags.append(i.get('RepoTags'))
 
-        self.assertFalse('docker-test-image' in [tag for tag in repotags])
-        if ['docker-test-image:latest'] in \
+        self.assertFalse(TEST_IMAGE in [tag for tag in repotags])
+        if ['{0}:latest'.format(TEST_IMAGE)] in \
                 [i.get('RepoTags') for i in client.images()]:
-            client.remove_image('docker-test-image', force=True)
+            client.remove_image(TEST_IMAGE, force=True)
+

--- a/docker_plugin/tests/tests_tasks.py
+++ b/docker_plugin/tests/tests_tasks.py
@@ -25,6 +25,8 @@ from cloudify.mocks import MockCloudifyContext
 from docker_plugin import tasks
 from cloudify.exceptions import NonRecoverableError
 
+TEST_IMAGE = 'tutum/hello-world'
+
 
 class TestTasks(testtools.TestCase):
 
@@ -37,7 +39,7 @@ class TestTasks(testtools.TestCase):
         test_properties = {
             'name': test_name,
             'image': {
-                'repository': 'docker-test-image'
+                'repository': TEST_IMAGE
             }
         }
 
@@ -60,7 +62,7 @@ class TestTasks(testtools.TestCase):
 
     def pull_image(self, client):
         output = []
-        for line in client.pull('docker-test-image', stream=True):
+        for line in client.pull(TEST_IMAGE, stream=True):
             output.append(json.dumps(json.loads(line)))
         return output
 
@@ -108,7 +110,7 @@ class TestTasks(testtools.TestCase):
         ctx.node.properties['use_external_resource'] = True
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 

--- a/docker_plugin/tests/tests_tasks.py
+++ b/docker_plugin/tests/tests_tasks.py
@@ -24,8 +24,7 @@ import docker
 from cloudify.mocks import MockCloudifyContext
 from docker_plugin import tasks
 from cloudify.exceptions import NonRecoverableError
-
-TEST_IMAGE = 'tutum/hello-world'
+from docker_plugin.tests import TEST_IMAGE
 
 
 class TestTasks(testtools.TestCase):

--- a/docker_plugin/tests/tests_utils.py
+++ b/docker_plugin/tests/tests_utils.py
@@ -27,6 +27,7 @@ from docker_plugin import utils
 
 TEST_IMAGE = 'tutum/hello-world'
 
+
 class TestUtils(testtools.TestCase):
 
     def setUp(self):

--- a/docker_plugin/tests/tests_utils.py
+++ b/docker_plugin/tests/tests_utils.py
@@ -24,8 +24,7 @@ import docker
 from cloudify.mocks import MockCloudifyContext
 from cloudify.exceptions import NonRecoverableError
 from docker_plugin import utils
-
-TEST_IMAGE = 'tutum/hello-world'
+from docker_plugin.tests import TEST_IMAGE
 
 
 class TestUtils(testtools.TestCase):

--- a/docker_plugin/tests/tests_utils.py
+++ b/docker_plugin/tests/tests_utils.py
@@ -25,6 +25,7 @@ from cloudify.mocks import MockCloudifyContext
 from cloudify.exceptions import NonRecoverableError
 from docker_plugin import utils
 
+TEST_IMAGE = 'tutum/hello-world'
 
 class TestUtils(testtools.TestCase):
 
@@ -37,7 +38,7 @@ class TestUtils(testtools.TestCase):
         test_properties = {
             'name': test_name,
             'image': {
-                'repository': 'docker-test-image'
+                'repository': TEST_IMAGE
             }
         }
 
@@ -60,7 +61,7 @@ class TestUtils(testtools.TestCase):
 
     def pull_image(self, client):
         output = []
-        for line in client.pull('docker-test-image', stream=True):
+        for line in client.pull(TEST_IMAGE, stream=True):
             output.append(json.dumps(json.loads(line)))
         return output
 
@@ -100,7 +101,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 
@@ -139,7 +140,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 
@@ -174,7 +175,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 
@@ -247,7 +248,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 
@@ -266,7 +267,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
         client = self.get_docker_client()
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
         container = self.create_container(client, name, image_id)
@@ -312,7 +313,7 @@ class TestUtils(testtools.TestCase):
         ctx = self.get_mock_context(name)
 
         for image in self.get_docker_images(client):
-            if 'docker-test-image:latest' in \
+            if '{0}:latest'.format(TEST_IMAGE) in \
                     self.get_tags_for_docker_image(image):
                 image_id = self.get_id_from_image(image)
 


### PR DESCRIPTION
It seems that docker removed their old docker test image "docker-test-image". I've updated these tests to use a popular image called "tutum/hello-world".