### PR TITLE
1.3m5 build

### DIFF
--- a/docker_plugin/tasks.py
+++ b/docker_plugin/tasks.py
@@ -129,7 +129,7 @@ def start(params, processes_to_wait_for, retry_interval,
 
     ctx.logger.info('Container: {0} Forwarded ports: {1} Top: {2}.'.format(
         ctx.instance.runtime_properties['container_id'],
-        inspect_output.get('Ports', None), top_info))
+        'Ports', top_info))
 
 
 @operation

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   docker:
     executor: host_agent
-    source: https://github.com/cloudify-cosmo/cloudify-docker-plugin/archive/1.3m5.zip
+    source: https://github.com/cenx-cf/cloudify-docker-plugin/archive/1.3m5-build.zip
 
 node_types:
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   docker:
     executor: host_agent
-    source: https://github.com/cloudify-cosmo/cloudify-docker-plugin/archive/1.3m7.zip
+    source: https://github.com/cloudify-cosmo/cloudify-docker-plugin/archive/1.3m5.zip
 
 node_types:
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,7 +5,7 @@
 plugins:
   docker:
     executor: host_agent
-    source: https://github.com/cenx-cf/cloudify-docker-plugin/archive/1.3m5-build.zip
+    source: https://github.com/cloudify-cosmo/cloudify-docker-plugin/archive/1.3m7.zip
 
 node_types:
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     license='LICENCE',
     install_requires=[
         'cloudify-plugins-common>=3.3a5',
-        'docker-py==1.2.3'
+        'docker-py==1.4.0'
     ],
     packages=['docker_plugin'],
     zip_safe=False


### PR DESCRIPTION
Changes are done in the cloudify-docker-plugin to have the updated version of Docker-py and workaround of bug in task.py. Please go though the changes and if it looks good, merge those in the main branch.

Changes:

1) Updated 'docker-py==1.2.3' to 'docker-py==1.4.0' in setup.py (line 28)
2) Updated source link to use my repository instead of default in plugin.yaml, i.e. (line 8)

from 
https://github.com/cloudify-cosmo/cloudify-docker-plugin/archive/1.3m5.zip
to
https://github.com/cenx-cf/cloudify-docker-plugin/archive/1.3m5-build.zip

3) (Workaround) Modified tasks.py to use String instead of undefined variable in task.py: (line 132)

from 
inspect_output.get('Ports', None), top_info))
to
'Ports', top_info))