### PR TITLE
Correcting errors when using latest Docker version

### DIFF
--- a/docker_plugin/tasks.py
+++ b/docker_plugin/tasks.py
@@ -294,6 +294,13 @@ def import_image(client, arguments):
             'Failed to start container: {0}.'.format(str(e)))
 
     ctx.logger.info('output: {}'.format(output))
+
+    # json.loads crashes when trying to import a URL image because
+    # output have more than one JSON object solution, skip every
+    # JSON until the result JSON arrives (last one)
+    lines = output.split('\n', (output.count('\n')+1))
+    output = lines[len(lines)-1]
+
     image_id = json.loads(output).get('status')
 
     image_id = utils.get_image_id(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import setuptools
 setuptools.setup(
 
     name='cloudify-docker-plugin',
-    version='1.3.1',
+    version='1.3.2.dev',
     author='Gigaspaces',
     author_email='cosmo-admin@gigaspaces.com',
     description='A Cloudify plugin enabling it to create'


### PR DESCRIPTION
daconstenla commented 5 days ago
With latest version of Docker, Docker version 1.10.1, build 9e83765, response to import_image query contains multiple JSON objects and json.loads only supports one. Skipping every JSON except the last, works as spected.