### PR TITLE
CFY-4698 fix connection errors in docker plugin system tests

### DIFF
--- a/system_tests/manager/test_docker_plugin.py
+++ b/system_tests/manager/test_docker_plugin.py
@@ -15,7 +15,7 @@
 import os
 
 from fabric.api import settings, run
-
+from fabric.network import disconnect_all
 from cloudify.workflows import local
 from cosmo_tester.framework.testenv import TestCase
 from cosmo_tester.framework.cfy_helper import cfy
@@ -102,6 +102,8 @@ class TestDockerPlugin(TestCase):
                   'nosetests --with-cov --cov-report term-missing ' \
                   '--cov docker_system_test/docker_plugin ' \
                   'docker_system_test/docker_plugin/tests'
+            
+        disconnect_all()
 
         with settings(**fabric_env):
             result = run(command)


### PR DESCRIPTION
The "permission denied" error (when connecting to a docker socket)
was caused by the fabric user not being in the docker group.
Groups are only refreshed after a new login.
Most of the time fabric would indeed use a new connection, but sometimes
it would reuse an existing one.

This makes the system test forcibly disconnect all cached fabric
connections, so when it first uses docker, it necessarily needs to
log in again.